### PR TITLE
fix: Update React-Core pod to support use_frameworks!

### DIFF
--- a/react-native-daily-js.podspec
+++ b/react-native-daily-js.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,c,m,swift}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   # ...
   # s.dependency "..."
 end


### PR DESCRIPTION
Update podspec since native APIs seems to reside on the React-Core, fixing build errors when making use of `use_frameworks!` and Xcode 12+

See: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116