### PR TITLE
Remove bitcode step from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,6 @@ Update the `platform` in your `Podfile`, since `@daily-co/react-native-webrtc` o
 platform :ios, '11.0'
 ```
 
-If you plan on doing a release build with bitcode enabled, run:
-
-```
-./node_modules/@daily-co/react-native-webrtc/tools/downloadBitcode.sh
-```
-
-(But don't fret—you can always run it later, before you do your release build.)
-
 Then run:
 
 ```bash


### PR DESCRIPTION
Since bitcode support is removed since Xcode 14 and [now also removed from `react-native-webrtc`](https://github.com/react-native-webrtc/react-native-webrtc/commit/350d4fbb26dab8aa686afea6432577b543451018#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519)