### PR TITLE
fix(android): catch foreground service crashes on Android 12-14

### DIFF
--- a/android/src/main/java/com/daily/reactlibrary/DailyOngoingMeetingForegroundService.java
+++ b/android/src/main/java/com/daily/reactlibrary/DailyOngoingMeetingForegroundService.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.IBinder;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -38,7 +39,11 @@ public class DailyOngoingMeetingForegroundService extends Service {
         intent.putExtra(EXTRA_TITLE, title);
         intent.putExtra(EXTRA_SUBTITLE, subtitle);
         intent.putExtra(EXTRA_ICON_NAME, iconName);
-        ContextCompat.startForegroundService(context, intent);
+        try {
+            ContextCompat.startForegroundService(context, intent);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to start foreground service: " + e.getMessage(), e);
+        }
     }
 
     public static void stop(Context context) {
@@ -86,7 +91,12 @@ public class DailyOngoingMeetingForegroundService extends Service {
                 .setOnlyAlertOnce(true)
                 .build();
 
-        startForeground(NOTIFICATION_ID, notification);
+        try {
+            startForeground(NOTIFICATION_ID, notification);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to promote service to foreground: " + e.getMessage(), e);
+            stopSelf();
+        }
 
         return START_NOT_STICKY;
     }


### PR DESCRIPTION
fix(android): catch foreground service crashes on Android 12-14

Daily's DailyOngoingMeetingForegroundService has two unguarded calls
that throw fatal RuntimeExceptions on certain Android versions:

- `startForegroundService()` throws ForegroundServiceStartNotAllowedException
  on Android 12+ when the app is in the background at the time of the call
- `startForeground()` throws SecurityException on Android 14+ when the
  microphone foreground service type requirements are not met (eligible
  state/exemption check)

Both are native crashes (UncaughtExceptionHandler, handled=false) that
kill the app entirely and cannot be caught from JavaScript.

Example fatal error from production:
```
ForegroundServiceStartNotAllowedException: startForegroundService() not allowed due to mAllowStartForeground false: service com.hanashiapp.hanashi/com.daily.reactlibrary.DailyOngoingMeetingForegroundService
```

Wrap both calls in try-catch blocks so the service fails gracefully. The
only degradation is the loss of the in-call notification and background
keep-alive — the call itself continues to work while the app is in the
foreground.