### PR TITLE
fix: support async-storage 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This package introduces some constraints on what OS/SDK versions your project ca
 Install `react-native-daily-js` along with its peer dependencies:
 
 ```bash
-npm i @daily-co/react-native-daily-js @react-native-async-storage/async-storage@^1.15.7 react-native-background-timer@^2.3.1 react-native-get-random-values@^1.9.0
+npm i @daily-co/react-native-daily-js @react-native-async-storage/async-storage@^2.0.0 react-native-background-timer@^2.3.1 react-native-get-random-values@^1.9.0
 npm i --save-exact @daily-co/react-native-webrtc@124.0.6-daily.1
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@daily-co/react-native-webrtc": "^124.0.6-daily.1",
-        "@react-native-async-storage/async-storage": "^1.24.0",
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@types/base-64": "^1.0.0",
         "@types/react": "18.3.21",
         "react-native": "0.76.9",
@@ -25,7 +25,7 @@
       },
       "peerDependencies": {
         "@daily-co/react-native-webrtc": "^124.0.6-daily.1",
-        "@react-native-async-storage/async-storage": "^1.24.0",
+        "@react-native-async-storage/async-storage": "^1.24.0 || ^2.0.0",
         "react-native": ">=0.68.0",
         "react-native-background-timer": "^2.4.1",
         "react-native-get-random-values": "^1.11.0"
@@ -1648,15 +1648,16 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
-      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "merge-options": "^3.0.4"
       },
       "peerDependencies": {
-        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
   "///": "WHEN ONE OF THESE CHANGE, PLEASE UPDATE README.md INSTALL SNIPPET ACCORDINGLY",
   "peerDependencies": {
     "@daily-co/react-native-webrtc": "^124.0.6-daily.1",
-    "@react-native-async-storage/async-storage": "^1.24.0",
+    "@react-native-async-storage/async-storage": "^1.24.0 || ^2.0.0",
     "react-native": ">=0.68.0",
     "react-native-background-timer": "^2.4.1",
     "react-native-get-random-values": "^1.11.0"
   },
   "devDependencies": {
     "@daily-co/react-native-webrtc": "^124.0.6-daily.1",
-    "@react-native-async-storage/async-storage": "^1.24.0",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@types/base-64": "^1.0.0",
     "@types/react": "18.3.21",
     "react-native": "0.76.9",


### PR DESCRIPTION
## Summary
- widen the AsyncStorage peer dependency to accept `^1.24.0 || ^2.0.0`
- keep local development on AsyncStorage `2.2.0`
- update the README install guidance to recommend AsyncStorage `^2.0.0`

## Why
`react-native-daily-js` currently peers on AsyncStorage 1.x only, which creates dependency-resolution problems in Expo-managed apps that correctly install AsyncStorage 2.x.

This change preserves compatibility for existing AsyncStorage `1.24.x` consumers while allowing Expo apps to resolve the SDK-aligned AsyncStorage 2.x versions they already expect.

This library only uses AsyncStorage in one cache module and only relies on the basic promise-based `getItem` / `setItem` / `removeItem` API, so this change is primarily about widening package compatibility rather than changing runtime behavior.

## Validation
I validated this change in fresh scratch apps rather than only in this package repo.

### Expo-managed apps
- Expo SDK 53
  - AsyncStorage resolved to `2.1.2`
  - installed this branch successfully
  - `expo-doctor`: `17/17 checks passed`
- Expo SDK 55
  - AsyncStorage resolved to `2.2.0`
  - installed this branch successfully
  - `expo-doctor` reported no AsyncStorage-related issues

### Bare React Native
- React Native `0.76.9` + AsyncStorage `1.24.0`
  - install passed with `--strict-peer-deps`
  - `npx pod-install` passed
  - `./gradlew help` passed
- React Native `0.76.9` + AsyncStorage `2.2.0`
  - install passed with `--strict-peer-deps`
  - `npx pod-install` passed
  - `./gradlew help` passed

This was checked against both the existing 1.x path and the new Expo-driven 2.x path so the widened peer range reflects real install compatibility.

Closes #70